### PR TITLE
Support for Pusher Beams (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # react-native-pusher-push-notifications
+
 Manage pusher interest subscriptions from within React Native JS
 
-IMPORTANT!!! This module is intended to complement the default [Pusher setup](https://pusher.com/docs/push_notifications).  This module simply allows that implementation to be accessed directly from React Native JS.
+**IMPORTANT!!!**
+
+This module is intended to complement the default [Pusher Carthage setup](https://docs.pusher.com/beams/ios/sdk-integration#install-from-carthage). This module simply allows that implementation to be accessed directly from React Native JS.
+
+More information about Pusher Beams and their Swift library, `push-notifications-swift`, can be found on their [Github repo](https://github.com/pusher/push-notifications-swift).
+
+There are some issues installing this repo you need to be aware of. More info can be found in [issue 65](https://github.com/pusher/push-notifications-swift/issues/65).
 
 [![npm version](https://badge.fury.io/js/react-native-pusher-push-notifications.svg)](https://badge.fury.io/js/react-native-pusher-push-notifications)
 
 ## Getting started
 
 `$ npm install react-native-pusher-push-notifications --save`
+
+or yarn
+
+`$ yarn add react-native-pusher-push-notifications`
 
 ### Mostly automatic installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Manage pusher interest subscriptions from within React Native JS
 
 **IMPORTANT!!!**
 
-This module is intended to complement the default [Pusher Carthage setup](https://docs.pusher.com/beams/ios/sdk-integration#install-from-carthage). This module simply allows that implementation to be accessed directly from React Native JS.
+This module is intended to complement the setup with [Carthage](https://docs.pusher.com/beams/ios/sdk-integration#install-from-carthage). This module allows that implementation to be accessed directly from React Native JS.
 
 More information about Pusher Beams and their Swift library, `push-notifications-swift`, can be found on their [Github repo](https://github.com/pusher/push-notifications-swift).
 
@@ -28,9 +28,9 @@ or yarn
 
 #### iOS
 
-1.  In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
+1.  In Xcode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2.  Go to `node_modules` ➜ `react-native-pusher-push-notifications` and add `RNPusherPushNotifications.xcodeproj`
-3.  In XCode, in the project navigator, select your project. Add `libRNPusherPushNotifications.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+3.  In Xcode, in the project navigator, select your project. Add `libRNPusherPushNotifications.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4.  Run your project (`Cmd+R`)<
 
 #### Android

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ or yarn
 
 `$ yarn add react-native-pusher-push-notifications`
 
-### Mostly automatic installation
+### Automatic installation
 
-`$ react-native link react-native-pusher-push-notifications`
+React native link has shown to incorrectly setup projects, so follow the manual instructions below.
 
 ### Manual installation
 
@@ -31,54 +31,31 @@ or yarn
 1.  In Xcode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2.  Go to `node_modules` ➜ `react-native-pusher-push-notifications` and add `RNPusherPushNotifications.xcodeproj`
 3.  In Xcode, in the project navigator, select your project. Add `libRNPusherPushNotifications.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4.  Run your project (`Cmd+R`)<
-
-#### Android
-
-1.  Open up `android/app/src/main/java/[...]/MainActivity.java`
-
-- Add `import com.reactlibrary.RNPusherPushNotificationsPackage;` to the imports at the top of the file
-- Add `new RNPusherPushNotificationsPackage()` to the list returned by the `getPackages()` method
-
-2.  Append the following lines to `android/settings.gradle`:
-    ```
-    include ':react-native-pusher-push-notifications'
-    project(':react-native-pusher-push-notifications').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-react-native-pusher-push-notifications/android')
-    ```
-3.  Insert the following lines inside the dependencies block in `android/app/build.gradle`:
-    ```
-      compile project(':react-native-pusher-push-notifications')
-    ```
-
-### All installations
-
-#### iOS
 
 ** DO NOT follow the pusher.com push notification docs that detail modifying the AppDelegate.h/m files! - this package takes care of most of the steps for you**
 
-1.  After package installation open `AppDelegate.h` and add:
+1.  Open `AppDelegate.m` and add:
 
 ```aidl
-    #import <RNPusherPushNotifications.h>
-    // ..after @implements and before @end
-    @property (nonatomic, strong) RNPusherPushNotifications *RNPusher;
-```
-
-2.  Open `AppDelegate.m` and add:
-
-```aidl
-    // Inside didFinishLaunchingWithOptions, near the bottom (after rootView has been initialised)
-    self.RNPusher = [((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"];
-
     // Add the following as a new methods to AppDelegate.m
     - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-      [[((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"] setDeviceToken:deviceToken];
+      NSLog(@"Registered for remote with token: %@", deviceToken);
+      [[RNPusherPushNotifications alloc] setDeviceToken:deviceToken];
     }
-
+    
     - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
-  [[((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"] handleNotification:userInfo];
-}
+      [[RNPusherPushNotifications alloc] handleNotification:userInfo];
+    }
+    
+    -(void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+      NSLog(@"Remote notification support is unavailable due to error: %@", error.localizedDescription);
+    }
 ```
+
+#### Android
+
+COMING SOON
+
 
 ## Usage
 
@@ -87,7 +64,21 @@ or yarn
 import RNPusherPushNotifications from 'react-native-pusher-push-notifications';
 
 // Get your interest
-const donutsInterest = 'donuts';
+const donutsInterest = 'debug-donuts';
+
+// Initialize notifications
+export const init = () => {
+    // Set your app key and register for push
+    RNPusherPushNotifications.setInstanceId(CONSTANTS.PUSHER_INSTANCE_ID);
+
+	// Init interests after registration
+	RNPusherPushNotifications.on('registered', () => {
+        subscribe(donutsInterest);
+    });
+
+	// Setup notification listeners
+	RNPusherPushNotifications.on('notification', handleNotification);
+};
 
 // Handle notifications received
 const handleNotification = notification => {
@@ -108,30 +99,42 @@ const subscribe = interest => {
   );
 };
 
-// Set your app key and register for push
-RNPusherPushNotifications.setInstanceId(CONSTANTS.PUSHER_BEAMS_INSTANCE_ID);
-
-// Init interests after registration
-RNPusherPushNotifications.on('registered', () => subscribe(donutsInterest));
-
-// Setup notification listeners
-RNPusherPushNotifications.on('notification', handleNotification);
-
-// Unsubscribe from interest
-RNPusherPushNotifications.unsubscribe('interest-1', error => {}, success => {});
+// Unsubscribe from an interest
+const unsubscribe = (interest) => {
+    RNPusherPushNotifications.unsubscribe(
+        interest,
+        (statusCode, response) => {
+            console.tron.logImportant(statusCode, response);
+        },
+        () => {
+            console.tron.logImportant("Success");
+        }
+    );
+};
 ```
 
 ## iOS only methods
 
 ```javascript
-// Subscribe to multiple interests with one request
-RNPusherPushNotifications.setSubScriptions(
-  ['interest-1', 'interest-2'],
-  error => {
-    console.log(error);
-  }
-);
-
-// Unsubscribe all interests
-RNPusherPushNotifications.unsubscribeAll();
+// Set interests
+const donutInterests = ['debug-donuts', 'debug-general'];
+const setSubscriptions = donutInterests => {
+  // Note that only Android devices will respond to success/error callbacks
+  RNPusherPushNotifications.setSubscriptions(
+    donutInterests,
+    (statusCode, response) => {
+      console.error(statusCode, response);
+    },
+    () => {
+      console.log('Success');
+    }
+  );
+};
 ```
+
+## Troubleshooting
+1. `dyld: Library not loaded: @rpath/PushNotifications.framework/PushNotifications`
+Ensure the PushNotifications.framework library is added to `General => Embedded Binaries`
+
+2. `dyld: Library not loaded: @rpath/libswiftCore.dylib`
+Ensure `Build Settings => Always Embed Swift Standard Libraries` is set to `Yes` and a valid Development provisioning profile exists on your system.

--- a/README.md
+++ b/README.md
@@ -28,25 +28,27 @@ or yarn
 
 #### iOS
 
-1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2. Go to `node_modules` ➜ `react-native-pusher-push-notifications` and add `RNPusherPushNotifications.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRNPusherPushNotifications.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4. Run your project (`Cmd+R`)<
+1.  In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
+2.  Go to `node_modules` ➜ `react-native-pusher-push-notifications` and add `RNPusherPushNotifications.xcodeproj`
+3.  In XCode, in the project navigator, select your project. Add `libRNPusherPushNotifications.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+4.  Run your project (`Cmd+R`)<
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
-  - Add `import com.reactlibrary.RNPusherPushNotificationsPackage;` to the imports at the top of the file
-  - Add `new RNPusherPushNotificationsPackage()` to the list returned by the `getPackages()` method
-2. Append the following lines to `android/settings.gradle`:
-  	```
-  	include ':react-native-pusher-push-notifications'
-  	project(':react-native-pusher-push-notifications').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-react-native-pusher-push-notifications/android')
-  	```
-3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
-  	```
+1.  Open up `android/app/src/main/java/[...]/MainActivity.java`
+
+- Add `import com.reactlibrary.RNPusherPushNotificationsPackage;` to the imports at the top of the file
+- Add `new RNPusherPushNotificationsPackage()` to the list returned by the `getPackages()` method
+
+2.  Append the following lines to `android/settings.gradle`:
+    ```
+    include ':react-native-pusher-push-notifications'
+    project(':react-native-pusher-push-notifications').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-react-native-pusher-push-notifications/android')
+    ```
+3.  Insert the following lines inside the dependencies block in `android/app/build.gradle`:
+    ```
       compile project(':react-native-pusher-push-notifications')
-  	```
+    ```
 
 ### All installations
 
@@ -54,13 +56,16 @@ or yarn
 
 ** DO NOT follow the pusher.com push notification docs that detail modifying the AppDelegate.h/m files! - this package takes care of most of the steps for you**
 
-1. After package installation open `AppDelegate.h` and add:
+1.  After package installation open `AppDelegate.h` and add:
+
 ```aidl
     #import <RNPusherPushNotifications.h>
     // ..after @implements and before @end
     @property (nonatomic, strong) RNPusherPushNotifications *RNPusher;
 ```
-2. Open `AppDelegate.m` and add:
+
+2.  Open `AppDelegate.m` and add:
+
 ```aidl
     // Inside didFinishLaunchingWithOptions, near the bottom (after rootView has been initialised)
     self.RNPusher = [((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"];
@@ -70,58 +75,59 @@ or yarn
       [[((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"] setDeviceToken:deviceToken];
     }
 
-    - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-      [[((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"] handleNotification:notification];
-    }
+    - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+  [[((RCTRootView *) self.window.rootViewController.view).bridge moduleForName:@"RNPusherPushNotifications"] handleNotification:userInfo];
+}
 ```
 
 ## Usage
+
 ```javascript
-  // Import module
-  import RNPusherPushNotifications from 'react-native-pusher-push-notifications';
+// Import module
+import RNPusherPushNotifications from 'react-native-pusher-push-notifications';
 
-  // Get your interest
-  const donutsInterest = "donuts";
+// Get your interest
+const donutsInterest = 'donuts';
 
-  // Set your app key and register for push
-  RNPusherPushNotifications.setAppKey(CONSTANTS.PUSHER_APP_KEY);
+// Handle notifications received
+const handleNotification = notification => {
+  console.log(notification);
+};
 
-  // Init interests after registration
-  RNPusherPushNotifications.on('registered', subscribe(donutsInterest));
+// Subscribe to an interest
+const subscribe = interest => {
+  // Note that only Android devices will respond to success/error callbacks
+  RNPusherPushNotifications.subscribe(
+    interest,
+    (statusCode, response) => {
+      console.error(statusCode, response);
+    },
+    () => {
+      console.log('Success');
+    }
+  );
+};
 
-  // Setup notification listeners
-  RNPusherPushNotifications.on('notification', handleNotification);
+// Set your app key and register for push
+RNPusherPushNotifications.setInstanceId(CONSTANTS.PUSHER_BEAMS_INSTANCE_ID);
 
-  // Handle notifications received
-  const handleNotification = (notification) => {
-    console.log(notification);
-  };
+// Init interests after registration
+RNPusherPushNotifications.on('registered', () => subscribe(donutsInterest));
 
-  // Subscribe to an interest
-  const subscribe = (interest) => {
-    // Note that only Android devices will respond to success/error callbacks
-    RNPusherPushNotifications.subscribe(
-        interest,
-        (statusCode, response) => {
-            console.error(statusCode, response);
-        },
-        () => {
-            console.log("Success");
-        }
-    );
-  };
+// Setup notification listeners
+RNPusherPushNotifications.on('notification', handleNotification);
 
-  // Unsubscribe an interest
-  const unsubscribe = (interest) => {
-    // Note that only Android devices will respond to success/error callbacks
-    RNPusherPushNotifications.unsubscribe(
-        interest,
-        (statusCode, response) => {
-            console.error(statusCode, response);
-        },
-        () => {
-            console.log("Success");
-        }
-    );
-  };
+// Unsubscribe an interest
+const unsubscribe = interest => {
+  // Note that only Android devices will respond to success/error callbacks
+  RNPusherPushNotifications.unsubscribe(
+    interest,
+    (statusCode, response) => {
+      console.error(statusCode, response);
+    },
+    () => {
+      console.log('Success');
+    }
+  );
+};
 ```

--- a/README.md
+++ b/README.md
@@ -117,17 +117,21 @@ RNPusherPushNotifications.on('registered', () => subscribe(donutsInterest));
 // Setup notification listeners
 RNPusherPushNotifications.on('notification', handleNotification);
 
-// Unsubscribe an interest
-const unsubscribe = interest => {
-  // Note that only Android devices will respond to success/error callbacks
-  RNPusherPushNotifications.unsubscribe(
-    interest,
-    (statusCode, response) => {
-      console.error(statusCode, response);
-    },
-    () => {
-      console.log('Success');
-    }
-  );
-};
+// Unsubscribe from interest
+RNPusherPushNotifications.unsubscribe('interest-1', error => {}, success => {});
+```
+
+## iOS only methods
+
+```javascript
+// Subscribe to multiple interests with one request
+RNPusherPushNotifications.setSubScriptions(
+  ['interest-1', 'interest-2'],
+  error => {
+    console.log(error);
+  }
+);
+
+// Unsubscribe all interests
+RNPusherPushNotifications.unsubscribeAll();
 ```

--- a/index.js
+++ b/index.js
@@ -1,38 +1,70 @@
-'use strict';
+import {
+  DeviceEventEmitter,
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+} from 'react-native';
 
-import { DeviceEventEmitter, NativeEventEmitter, NativeModules, Platform } from 'react-native';
-const { RNPusherPushNotifications } = NativeModules
-const rnPusherPushNotificationsEmitter = new NativeEventEmitter(RNPusherPushNotifications)
+const { RNPusherPushNotifications } = NativeModules;
+const rnPusherPushNotificationsEmitter = new NativeEventEmitter(
+  RNPusherPushNotifications
+);
 
-const errorCallback = callback => (statusCode, response) => callback && callback(statusCode, response);
+const errorCallback = callback => (statusCode, response) =>
+  callback && callback(statusCode, response);
 const successCallback = callback => () => callback && callback();
 
 export default {
-  setAppKey: (appKey) => {
-    RNPusherPushNotifications.setAppKey(appKey)
+  setInstanceId: instanceId => {
+    if (Platform.OS === 'ios') {
+      RNPusherPushNotifications.setInstanceId(instanceId);
+    } else {
+      RNPusherPushNotifications.setAppKey(instanceId);
+    }
   },
   subscribe: (channel, onError, onSuccess) => {
     if (Platform.OS === 'ios') {
-      RNPusherPushNotifications.subscribe(channel)
+      RNPusherPushNotifications.subscribe(channel, onError);
     } else {
-      RNPusherPushNotifications.subscribe(channel, errorCallback(onError), successCallback(onSuccess))
+      RNPusherPushNotifications.subscribe(
+        channel,
+        errorCallback(onError),
+        successCallback(onSuccess)
+      );
+    }
+  },
+  setSubscriptions: (interests, onError) => {
+    if (Platform.OS === 'ios') {
+      RNPusherPushNotifications.setSubscriptions(interests, onError);
+    } else {
+      console.log('Not implemented yet');
     }
   },
   unsubscribe: (channel, onError, onSuccess) => {
     if (Platform.OS === 'ios') {
-      RNPusherPushNotifications.unsubscribe(channel)
+      RNPusherPushNotifications.unsubscribe(channel, onError);
     } else {
-      RNPusherPushNotifications.unsubscribe(channel, errorCallback(onError), successCallback(onSuccess))
+      RNPusherPushNotifications.unsubscribe(
+        channel,
+        errorCallback(onError),
+        successCallback(onSuccess)
+      );
+    }
+  },
+  unsubscribeAll: (onError, onSuccess) => {
+    if (Platform.OS === 'ios') {
+      RNPusherPushNotifications.unsubscribeAll();
+    } else {
+      console.log('Not implemented yet');
     }
   },
   on: (eventName, callback) => {
     if (Platform.OS === 'ios') {
-      rnPusherPushNotificationsEmitter.addListener(
-        eventName,
-        (payload) => callback(payload)
-      )
+      rnPusherPushNotificationsEmitter.addListener(eventName, payload =>
+        callback(payload)
+      );
     } else {
-      DeviceEventEmitter.addListener(eventName, (payload) => callback(payload));
+      DeviceEventEmitter.addListener(eventName, payload => callback(payload));
     }
-  }
+  },
 };

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ import {
   Platform,
 } from 'react-native';
 
-const { RNPusherPushNotifications } = NativeModules;
+const { RNPusherPushNotifications, RNPusherEventHelper } = NativeModules;
 const rnPusherPushNotificationsEmitter = new NativeEventEmitter(
-  RNPusherPushNotifications
+    RNPusherEventHelper
 );
 
 const errorCallback = callback => (statusCode, response) =>
@@ -49,13 +49,6 @@ export default {
         errorCallback(onError),
         successCallback(onSuccess)
       );
-    }
-  },
-  unsubscribeAll: (onError, onSuccess) => {
-    if (Platform.OS === 'ios') {
-      RNPusherPushNotifications.unsubscribeAll();
-    } else {
-      console.log('Not implemented yet');
     }
   },
   on: (eventName, callback) => {

--- a/ios/RNPusherEventHelper.h
+++ b/ios/RNPusherEventHelper.h
@@ -1,0 +1,8 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RNPusherEventHelper : RCTEventEmitter
+
++ (void)emitEventWithName:(NSString *)name andPayload:(NSDictionary *)payload;
+
+@end

--- a/ios/RNPusherEventHelper.m
+++ b/ios/RNPusherEventHelper.m
@@ -1,0 +1,52 @@
+#import "RNPusherEventHelper.h"
+
+@implementation RNPusherEventHelper
+
+RCT_EXPORT_MODULE();
+
+// The list of available events
+- (NSArray<NSString *> *)supportedEvents {
+    return @[@"registered", @"notification"];
+}
+
+// This function listens for the events we want to send out and will then pass the
+// payload over to the emitEventInternal function for sending to Javascript
+- (void)startObserving
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(emitEventInternal:)
+                                                 name:@"event-emitted"
+                                               object:nil];
+}
+
+// This will stop listening if we require it
+- (void)stopObserving
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+// This will actually throw the event out to our Javascript
+- (void)emitEventInternal:(NSNotification *)notification
+{
+    // We will receive the dictionary here - we now need to extract the name
+    // and payload and throw the event
+    NSArray *eventDetails = [notification.userInfo valueForKey:@"detail"];
+    NSString *eventName = [eventDetails objectAtIndex:0];
+    NSDictionary *eventData = [eventDetails objectAtIndex:1];
+    
+    [self sendEventWithName:eventName
+                       body:eventData];
+}
+
+// This is our static function that we call from our code
++ (void)emitEventWithName:(NSString *)name andPayload:(NSDictionary *)payload
+{
+    // userInfo requires a dictionary so we wrap out name and payload into an array and stick
+    // that into the dictionary with a key of 'detail'
+    NSDictionary *eventDetail = @{@"detail":@[name,payload]};
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"event-emitted"
+                                                        object:self
+                                                      userInfo:eventDetail];
+}
+
+@end

--- a/ios/RNPusherPushNotifications.h
+++ b/ios/RNPusherPushNotifications.h
@@ -1,12 +1,6 @@
-#if __has_include(<React/RCTBridgeModule.h>)
-  #import <React/RCTBridgeModule.h>
-#else
-  #import "RCTBridgeModule.h"
-#endif
+#import <React/RCTBridgeModule.h>
 
-#import <React/RCTEventEmitter.h>
-
-@interface RNPusherPushNotifications : RCTEventEmitter <RCTBridgeModule>
+@interface RNPusherPushNotifications : NSObject <RCTBridgeModule>
 
 -(void)setDeviceToken:(NSData *)deviceToken;
 -(void)handleNotification:(NSDictionary *)userInfo;

--- a/ios/RNPusherPushNotifications.h
+++ b/ios/RNPusherPushNotifications.h
@@ -5,14 +5,10 @@
 #endif
 
 #import <React/RCTEventEmitter.h>
-#import <Pusher/Pusher.h>
 
-@interface RNPusherPushNotifications : RCTEventEmitter <RCTBridgeModule, PTPusherDelegate>
-
-@property (nonatomic) PTPusher *pusher;
+@interface RNPusherPushNotifications : RCTEventEmitter <RCTBridgeModule>
 
 -(void)setDeviceToken:(NSData *)deviceToken;
 -(void)handleNotification:(NSDictionary *)notification;
 
 @end
-  

--- a/ios/RNPusherPushNotifications.h
+++ b/ios/RNPusherPushNotifications.h
@@ -9,6 +9,6 @@
 @interface RNPusherPushNotifications : RCTEventEmitter <RCTBridgeModule>
 
 -(void)setDeviceToken:(NSData *)deviceToken;
--(void)handleNotification:(NSDictionary *)notification;
+-(void)handleNotification:(NSDictionary *)userInfo;
 
 @end

--- a/ios/RNPusherPushNotifications.m
+++ b/ios/RNPusherPushNotifications.m
@@ -18,67 +18,65 @@ RCT_EXPORT_MODULE()
     return @[@"registered", @"notification"];
 }
 
-RCT_EXPORT_METHOD(getInterests:(RCTResponseSenderBlock)callback) {
-  NSArray *interests = [[PushNotifications shared] getInterests];
-  callback(@[[NSNull null], interests]);
-}
-
 RCT_EXPORT_METHOD(setInstanceId:(NSString *)instanceId)
 {
-  RCTLogInfo(@"Creating pusher with Instance ID: %@", instanceId);
-  [[PushNotifications shared] startWithInstanceId:instanceId];
-  [[PushNotifications shared] registerForRemoteNotifications];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RCTLogInfo(@"Creating pusher with Instance ID: %@", instanceId);
+
+    [[PushNotifications shared] startWithInstanceId:instanceId];
+    [[PushNotifications shared] registerForRemoteNotifications];
+  });
 }
 
 RCT_EXPORT_METHOD(subscribe:(NSString *)interest callback:(RCTResponseSenderBlock)callback) {
-  NSError *anyError;
-  [[PushNotifications shared] subscribeWithInterest:interest error:&anyError completion:^{
-    if (anyError) {
-      callback(@[anyError, [NSNull null]]);
-    }
-    else {
-      RCTLogInfo(@"Subscribed to interest: %@", interest);
-    }
-  }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSError *anyError;
+    [[PushNotifications shared] subscribeWithInterest:interest error:&anyError completion:^{
+      if (anyError) {
+        callback(@[anyError, [NSNull null]]);
+      }
+      else {
+        RCTLogInfo(@"Subscribed to interest: %@", interest);
+      }
+    }];
+  });
 }
 
 RCT_EXPORT_METHOD(setSubscriptions:(NSArray *)interests callback:(RCTResponseSenderBlock)callback) {
-  NSError *anyError;
-  [[PushNotifications shared] setSubscriptionsWithInterests:interests error:&anyError completion:^{
-    if (anyError) {
-      callback(@[anyError, [NSNull null]]);
-    }
-    else {
-      RCTLogInfo(@"Subscribed to interests: %@", interests);
-    }
-  }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSError *anyError;
+    [[PushNotifications shared] setSubscriptionsWithInterests:interests error:&anyError completion:^{
+      if (anyError) {
+        callback(@[anyError, [NSNull null]]);
+      }
+      else {
+        RCTLogInfo(@"Subscribed to interests: %@", interests);
+      }
+    }];
+  });
 }
 
-RCT_EXPORT_METHOD(subscribe:(NSString *)interest)
-{
-  RCTLogInfo(@"Subscribing to: %@", interest);
-  NSError *anyError;
-  [[PushNotifications shared] subscribeWithInterest:interest error:&anyError completion:^{
-    RCTLogInfo(@"Subscribed to interest: %@", interest);
-  }];
-}
 
 RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBlock)callback) {
-  NSError *anyError;
-  [[PushNotifications shared] unsubscribeWithInterest:interest error:&anyError completion:^{
-    if (anyError) {
-      callback(@[anyError, [NSNull null]]);
-    }
-    else {
-      RCTLogInfo(@"Unsubscribed from interest: %@", interest);
-    }
-  }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSError *anyError;
+    [[PushNotifications shared] unsubscribeWithInterest:interest error:&anyError completion:^{
+      if (anyError) {
+        callback(@[anyError, [NSNull null]]);
+      }
+      else {
+        RCTLogInfo(@"Unsubscribed from interest: %@", interest);
+      }
+    }];
+  });
 }
 
 RCT_EXPORT_METHOD(unsubscribeAll) {
-  [[PushNotifications shared] unsubscribeAllWithCompletion:^{
-    RCTLogInfo(@"Unsubscribed from all interests.");
-  }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[PushNotifications shared] unsubscribeAllWithCompletion:^{
+      RCTLogInfo(@"Unsubscribed from all interests.");
+    }];
+  });
 }
 
 - (void)handleNotification:(NSDictionary *)userInfo

--- a/ios/RNPusherPushNotifications.m
+++ b/ios/RNPusherPushNotifications.m
@@ -1,4 +1,4 @@
-
+#import "RNPusherEventHelper.h"
 #import "RNPusherPushNotifications.h"
 #import "UIKit/UIKit.h"
 #import <UIKit/UIKit.h>
@@ -7,15 +7,11 @@
 
 @implementation RNPusherPushNotifications
 
+RCT_EXPORT_MODULE();
+
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();
-}
-RCT_EXPORT_MODULE()
-
-- (NSArray<NSString *> *)supportedEvents
-{
-    return @[@"registered", @"notification"];
 }
 
 RCT_EXPORT_METHOD(setInstanceId:(NSString *)instanceId)
@@ -29,6 +25,7 @@ RCT_EXPORT_METHOD(setInstanceId:(NSString *)instanceId)
 }
 
 RCT_EXPORT_METHOD(subscribe:(NSString *)interest callback:(RCTResponseSenderBlock)callback) {
+  RCTLogInfo(@"Subscribing to interest: %@", interest);
   dispatch_async(dispatch_get_main_queue(), ^{
     NSError *anyError;
     [[PushNotifications shared] subscribeWithInterest:interest error:&anyError completion:^{
@@ -56,7 +53,6 @@ RCT_EXPORT_METHOD(setSubscriptions:(NSArray *)interests callback:(RCTResponseSen
   });
 }
 
-
 RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBlock)callback) {
   dispatch_async(dispatch_get_main_queue(), ^{
     NSError *anyError;
@@ -71,18 +67,10 @@ RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBl
   });
 }
 
-RCT_EXPORT_METHOD(unsubscribeAll) {
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [[PushNotifications shared] unsubscribeAllWithCompletion:^{
-      RCTLogInfo(@"Unsubscribed from all interests.");
-    }];
-  });
-}
-
 - (void)handleNotification:(NSDictionary *)userInfo
 {
     RCTLogInfo(@"handleNotification: %@", userInfo);
-    [self sendEventWithName:@"notification" body:userInfo];
+    [RNPusherEventHelper emitEventWithName:@"notification" andPayload:@{@"userInfo":userInfo}];
     [[PushNotifications shared] handleNotificationWithUserInfo:userInfo];
 }
 
@@ -90,8 +78,8 @@ RCT_EXPORT_METHOD(unsubscribeAll) {
 {
     RCTLogInfo(@"setDeviceToken: %@", deviceToken);
     [[PushNotifications shared] registerDeviceToken:deviceToken completion:^{
-      RCTLogInfo(@"SEND REGISTERED");
-      [self sendEventWithName:@"registered" body:@{}];
+        [RNPusherEventHelper emitEventWithName:@"registered" andPayload:@{}];
+        RCTLogInfo(@"REGISTERED!");
     }];
 }
 

--- a/ios/RNPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/RNPusherPushNotifications.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/Build/iOS/**";
 				HEADER_SEARCH_PATHS = (
 				"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -213,6 +214,7 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/Build/iOS/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/ios/RNPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/RNPusherPushNotifications.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B3E7B58A1CC2AC0600A0062D /* RNPusherPushNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNPusherPushNotifications.m */; };
+		BCA8A1002111819B00AC19BB /* RNPusherEventHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA8A0FF2111819B00AC19BB /* RNPusherEventHelper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -26,6 +27,8 @@
 		134814201AA4EA6300B7C361 /* libRNPusherPushNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNPusherPushNotifications.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNPusherPushNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPusherPushNotifications.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNPusherPushNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPusherPushNotifications.m; sourceTree = "<group>"; };
+		BCA8A0FE2111817900AC19BB /* RNPusherEventHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPusherEventHelper.h; sourceTree = "<group>"; };
+		BCA8A0FF2111819B00AC19BB /* RNPusherEventHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNPusherEventHelper.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -50,6 +53,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				BCA8A0FF2111819B00AC19BB /* RNPusherEventHelper.m */,
+				BCA8A0FE2111817900AC19BB /* RNPusherEventHelper.h */,
 				B3E7B5881CC2AC0600A0062D /* RNPusherPushNotifications.h */,
 				B3E7B5891CC2AC0600A0062D /* RNPusherPushNotifications.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -113,6 +118,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* RNPusherPushNotifications.m in Sources */,
+				BCA8A1002111819B00AC19BB /* RNPusherEventHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,6 +128,7 @@
 		58B511ED1A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -152,16 +159,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				STRIP_SWIFT_SYMBOLS = NO;
 			};
 			name = Debug;
 		};
 		58B511EE1A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -186,9 +196,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				STRIP_SWIFT_SYMBOLS = NO;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -198,7 +210,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/Build/iOS/**";
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../../ios/Pods/**",


### PR DESCRIPTION
Added support for the new Pusher Beams notifications via [pusher/push-notifications-swift](https://github.com/pusher/push-notifications-swift).

Added new information in readme on what to do to include Carthage frameworks. 

Discussed in #21 with @lukabratos and @b8ne