### PR TITLE
Add incrementBadge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ const setSubscriptions = donutInterests => {
 };
 ```
 
+## Increment Badge number
+
+The APS data sent to Pusher Beams and then to Apple have an option `badge`. This will update your apps badge counter to the current number. If you send 1, the badge will show 1. This means you need to handle notification read status in your backend and when pushing update to the current number.
+
+By adding `incrementBadge` you can increment the badge number without having to deal with your backend.
+
+```
+{
+  aps: {
+    data: {
+      incrementBadge: true
+    }
+  }
+}
+```
+
 ## Troubleshooting
 
 1.  `dyld: Library not loaded: @rpath/PushNotifications.framework/PushNotifications`

--- a/ios/RNPusherPushNotifications.m
+++ b/ios/RNPusherPushNotifications.m
@@ -89,6 +89,12 @@ RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBl
         appState = @"inactive";
     }
 
+    if((bool)[userInfo valueForKeyPath:@"aps.data.incrementBadge"]) {
+        NSInteger badgeCount = [[UIApplication sharedApplication] applicationIconBadgeNumber];
+        [UIApplication sharedApplication].applicationIconBadgeNumber = (badgeCount+1);
+        RCTLogInfo(@"increment badge number too: %ld", (long)( badgeCount+1 ));
+    }
+
     [RNPusherEventHelper emitEventWithName:@"notification" andPayload:@{
       @"userInfo":userInfo,
       @"appState":appState


### PR DESCRIPTION
Not 100% sure about this one but it would be an easy way for people to handle badge counters without having to deal with it in their backend. A use case could be that you push a notification for a new message and the badge counter should go up one for every one of these notifications.

As the Javascript handler won't be run until you open up the application you cannot do this here as you want to badge to update even if the app is in the background or inactive.

One other factor to consider is that you want to push a message to beams with multiple interests. Instead of making one push per user, to have individual badge counters, you can just do one push to Beams with this and it will increment badge number for all subscribers.

---

The APS data sent to Pusher Beams and then to Apple have an option `badge`. This will update your apps badge counter to the current number. If you send 1, the badge will show 1. This means you need to handle notification read status in your backend and when pushing update to the current number.

By adding `incrementBadge` you can increment the badge number without having to deal with your backend.

```
{
  aps: {
    data: {
      incrementBadge: true
    }
  }
}
```