### PR TITLE
Change compile to implementation in Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,8 +20,8 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
-    compile 'com.pusher:pusher-websocket-android:0.5.0'
-    compile 'com.google.firebase:firebase-messaging:9.8.0'
+    implementation 'com.facebook.react:react-native:0.20.+'
+    implementation 'com.pusher:pusher-websocket-android:0.5.0'
+    implementation 'com.google.firebase:firebase-messaging:9.8.0'
 }
   


### PR DESCRIPTION
This is required due to changes in Android Studio.

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```