### PR TITLE
Support pusher/push-notifications-swift 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Manage pusher interest subscriptions from within React Native JS
 
 **IMPORTANT!!!**
 
-This module is intended to complement the setup with [Carthage](https://docs.pusher.com/beams/ios/sdk-integration#install-from-carthage). This module allows that implementation to be accessed directly from React Native JS.
+This module is intended to complement the setup with [Carthage](https://pusher.com/docs/beams/getting-started/ios/sdk-integration#install-from-carthage). This module allows that implementation to be accessed directly from React Native JS.
+
+```Cartfile
+github "pusher/push-notifications-swift" ~> 2.0.0
+```
 
 More information about Pusher Beams and their Swift library, `push-notifications-swift`, can be found on their [Github repo](https://github.com/pusher/push-notifications-swift).
 

--- a/ios/RNPusherPushNotifications.m
+++ b/ios/RNPusherPushNotifications.m
@@ -28,42 +28,21 @@ RCT_EXPORT_METHOD(subscribe:(NSString *)interest callback:(RCTResponseSenderBloc
   RCTLogInfo(@"Subscribing to interest: %@", interest);
   dispatch_async(dispatch_get_main_queue(), ^{
     NSError *anyError;
-    [[PushNotifications shared] subscribeWithInterest:interest error:&anyError completion:^{
-      if (anyError) {
-        callback(@[anyError, [NSNull null]]);
-      }
-      else {
-        RCTLogInfo(@"Subscribed to interest: %@", interest);
-      }
-    }];
+    [[PushNotifications shared] addDeviceInterestWithInterest:interest error:&anyError];
   });
 }
 
 RCT_EXPORT_METHOD(setSubscriptions:(NSArray *)interests callback:(RCTResponseSenderBlock)callback) {
   dispatch_async(dispatch_get_main_queue(), ^{
     NSError *anyError;
-    [[PushNotifications shared] setSubscriptionsWithInterests:interests error:&anyError completion:^{
-      if (anyError) {
-        callback(@[anyError, [NSNull null]]);
-      }
-      else {
-        RCTLogInfo(@"Subscribed to interests: %@", interests);
-      }
-    }];
+    [[PushNotifications shared] setDeviceInterestsWithInterests:interests error:&anyError];
   });
 }
 
 RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBlock)callback) {
   dispatch_async(dispatch_get_main_queue(), ^{
     NSError *anyError;
-    [[PushNotifications shared] unsubscribeWithInterest:interest error:&anyError completion:^{
-      if (anyError) {
-        callback(@[anyError, [NSNull null]]);
-      }
-      else {
-        RCTLogInfo(@"Unsubscribed from interest: %@", interest);
-      }
-    }];
+    [[PushNotifications shared] removeDeviceInterestWithInterest:interest error:&anyError];
   });
 }
 
@@ -100,10 +79,9 @@ RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBl
 - (void)setDeviceToken:(NSData *)deviceToken
 {
     RCTLogInfo(@"setDeviceToken: %@", deviceToken);
-    [[PushNotifications shared] registerDeviceToken:deviceToken completion:^{
-        [RNPusherEventHelper emitEventWithName:@"registered" andPayload:@{}];
-        RCTLogInfo(@"REGISTERED!");
-    }];
+    [[PushNotifications shared] registerDeviceToken:deviceToken];
+    [RNPusherEventHelper emitEventWithName:@"registered" andPayload:@{}];
+    RCTLogInfo(@"REGISTERED!");
 }
 
 @end


### PR DESCRIPTION
Deprecated methods used when using latest push notifications lib. This fixes it.

https://github.com/pusher/push-notifications-swift/blob/master/CHANGELOG.md#200---2019-04-12

Fixes #37 