### PR TITLE
Push notifications android 1.4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,5 +49,5 @@ dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
     implementation 'com.google.firebase:firebase-core:16.0.1'
     implementation 'com.google.firebase:firebase-messaging:17.1.0'
-    implementation 'com.pusher:push-notifications-android:1.0.2'
+    implementation 'com.pusher:push-notifications-android:1.4.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pusher-push-notifications",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Manage pusher channel subscriptions from within React Native JS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pusher-push-notifications",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "description": "Manage pusher channel subscriptions from within React Native JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update to [push-notifications-android 1.4.0](https://github.com/pusher/push-notifications-android)

Also bump the release to [2.4.0](https://github.com/b8ne/react-native-pusher-push-notifications/blob/0ba6be35c924af94f775e95d349dbc94c7dbba7b/package.json#L3)

This can be tested before merging by adding this to `package.json`: 
```
"react-native-pusher-push-notifications": "git+http://git@github.com/ZeptInc/react-native-pusher-push-notifications#2.4.0"
```