### PR TITLE
Adds support for personal push notifications to Authenticated Users

### DIFF
--- a/RNPusherPushNotifications.podspec
+++ b/RNPusherPushNotifications.podspec
@@ -1,0 +1,16 @@
+require 'json'
+package = JSON.parse(File.read('./package.json'))
+
+Pod::Spec.new do |s|
+  s.name         = 'RNPusherPushNotifications'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.homepage     = "https://github.com/b8ne/react-native-pusher-push-notifications"
+  s.license      = { :type => 'MIT' }
+  s.author       = "Ben Sutter"
+  s.source       = { :git => "https://github.com/b8ne/react-native-pusher-push-notifications.git", :tag => "v#{s.version}" }
+  s.source_files = 'ios/**/*.{h,m}'
+  s.dependency 'React'
+  s.dependency 'PushNotifications', '~> 2.0.0'
+  s.platform = :ios, '10.0'
+end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,8 +46,10 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    compile 'com.facebook.react:react-native:+'
     implementation 'com.google.firebase:firebase-core:16.0.1'
     implementation 'com.google.firebase:firebase-messaging:17.1.0'
-    implementation 'com.pusher:push-notifications-android:1.0.2'
+    implementation 'com.pusher:push-notifications-android:1.4.1'
 }

--- a/android/src/main/java/com/b8ne/RNPusherPushNotifications/LocalTokenProvider.java
+++ b/android/src/main/java/com/b8ne/RNPusherPushNotifications/LocalTokenProvider.java
@@ -1,0 +1,16 @@
+package com.b8ne.RNPusherPushNotifications;
+
+import com.pusher.pushnotifications.auth.TokenProvider;
+
+public class LocalTokenProvider implements TokenProvider {
+  String _token;
+
+  public LocalTokenProvider(String token) {
+    _token = token;
+  }
+
+  @Override
+  public String fetchToken(String userId) {
+    return _token;
+  }
+}

--- a/android/src/main/java/com/b8ne/RNPusherPushNotifications/PusherWrapper.java
+++ b/android/src/main/java/com/b8ne/RNPusherPushNotifications/PusherWrapper.java
@@ -27,7 +27,6 @@ public class PusherWrapper {
     private String notificationEvent = "notification";
     private ReactContext context;
 
-
     public PusherWrapper(String appKey, final ReactContext context) {
         Log.d("PUSHER_WRAPPER", "Creating Pusher with App Key: " + appKey);
         System.out.print("Creating Pusher with App Key: " + appKey);
@@ -52,53 +51,55 @@ public class PusherWrapper {
         Log.i("PUSHER_WRAPPER", "onResume subscribing with activity " + getActivityName(activity));
         System.out.print("onResume subscribing with activity " + getActivityName(activity));
 
-        PushNotifications.setOnMessageReceivedListenerForVisibleActivity(activity, new PushNotificationReceivedListener() {
-            @Override
-            public void onMessageReceived(RemoteMessage remoteMessage) {
-                // Arguments.createMap seems to be for testing
-                // see: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java#L16
-                //WritableMap map = Arguments.createMap();
-                final WritableMap map = new WritableNativeMap();
-                RemoteMessage.Notification notification = remoteMessage.getNotification();
+        PushNotifications.setOnMessageReceivedListenerForVisibleActivity(activity,
+                new PushNotificationReceivedListener() {
+                    @Override
+                    public void onMessageReceived(RemoteMessage remoteMessage) {
+                        // Arguments.createMap seems to be for testing
+                        // see:
+                        // https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java#L16
+                        // WritableMap map = Arguments.createMap();
+                        final WritableMap map = new WritableNativeMap();
+                        RemoteMessage.Notification notification = remoteMessage.getNotification();
 
-                if(notification != null) {
-                    map.putString("body", notification.getBody());
-                    map.putString("title", notification.getTitle());
-                    map.putString("tag", notification.getTag());
-                    map.putString("click_action", notification.getClickAction());
-                    map.putString("icon", notification.getIcon());
-                    map.putString("color", notification.getColor());
-                    //map.putString("link", notification.getLink());
+                        if (notification != null) {
+                            map.putString("body", notification.getBody());
+                            map.putString("title", notification.getTitle());
+                            map.putString("tag", notification.getTag());
+                            map.putString("click_action", notification.getClickAction());
+                            map.putString("icon", notification.getIcon());
+                            map.putString("color", notification.getColor());
+                            // map.putString("link", notification.getLink());
 
-                    context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(notificationEvent, map);
-                    //System.out.print(remoteMessage.toString());
-                    Log.d("PUSHER_WRAPPER", "Notification received: " + notification.toString());
-                }
-                else {
-                    Log.d("PUSHER_WRAPPER", "No notification received");
-                }
-            }
-        });
+                            context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                    .emit(notificationEvent, map);
+                            // System.out.print(remoteMessage.toString());
+                            Log.d("PUSHER_WRAPPER", "Notification received: " + notification.toString());
+                        } else {
+                            Log.d("PUSHER_WRAPPER", "No notification received");
+                        }
+                    }
+                });
 
     }
 
     public void onDestroy(Activity activity) {
-        Log.i("PUSHER_WRAPPER", "onDestroy: " +getActivityName(activity));
+        Log.i("PUSHER_WRAPPER", "onDestroy: " + getActivityName(activity));
     }
 
     public void onPause(Activity activity) {
-        Log.i("PUSHER_WRAPPER", "onPause: " +getActivityName(activity));
+        Log.i("PUSHER_WRAPPER", "onPause: " + getActivityName(activity));
     }
 
     private String getActivityName(Activity activity) {
         return activity.getClass().getSimpleName();
     }
 
-    public void subscribe(final String interest, final Callback errorCallback,  final Callback successCallback) {
-        Log.d("PUSHER_WRAPPER", "Subscribing to " +  interest);
-        System.out.print("Subscribing to " +  interest);
+    public void subscribe(final String interest, final Callback errorCallback, final Callback successCallback) {
+        Log.d("PUSHER_WRAPPER", "Subscribing to " + interest);
+        System.out.print("Subscribing to " + interest);
         try {
-            //this.pushNotifications.subscribe(interest);
+            // this.pushNotifications.subscribe(interest);
             PushNotifications.subscribe(interest);
             Log.d("PUSHER_WRAPPER", "Success! " + interest);
             System.out.print("Success! " + interest);
@@ -111,7 +112,7 @@ public class PusherWrapper {
         }
     }
 
-    public void unsubscribe(final String interest, final Callback errorCallback,  final Callback successCallback) {
+    public void unsubscribe(final String interest, final Callback errorCallback, final Callback successCallback) {
         Log.d("PUSHER_WRAPPER", "Unsubscribing from " + interest);
         System.out.print("Unsubscribing from " + interest);
         try {
@@ -129,7 +130,7 @@ public class PusherWrapper {
         }
     }
 
-    public void unsubscribeAll(final Callback errorCallback,  final Callback successCallback) {
+    public void unsubscribeAll(final Callback errorCallback, final Callback successCallback) {
 
         try {
             PushNotifications.unsubscribeAll();
@@ -146,7 +147,7 @@ public class PusherWrapper {
         }
     }
 
-    public void getSubscriptions( final Callback subscriptionCallback, final Callback errorCallback) {
+    public void getSubscriptions(final Callback subscriptionCallback, final Callback errorCallback) {
         try {
             Set<String> subscriptionSet = PushNotifications.getSubscriptions();
             WritableArray subscriptions = new WritableNativeArray();
@@ -164,6 +165,27 @@ public class PusherWrapper {
         }
     }
 
+    public void setUserId(final String userId, final String token, final Callback errorCallback,
+            final Callback successCallback) {
+        Log.d("PUSHER_WRAPPER", "Setting userId to " + userId);
+        System.out.print("Setting userId to " + userId);
+        try {
+            LocalTokenProvider instance = new LocalTokenProvider(token);
+
+            PushNotifications.setUserId(userId, instance);
+
+            Log.d("PUSHER_WRAPPER", "Success! " + userId);
+            System.out.print("Success! " + userId);
+            successCallback.invoke();
+        } catch (Exception ex) {
+            Log.d("PUSHER_WRAPPER", "Exception in PusherWrapper " + ex.getMessage());
+            System.out.print("Exception in PusherWrapper.setUserId " + ex.getMessage());
+            // historically this is expecting a statusCode as first arg
+            errorCallback.invoke(0, ex.getMessage());
+        }
+
+    }
+
     public void setOnSubscriptionsChangedListener(final Callback subscriptionChangedListener) {
 
         PushNotifications.setOnSubscriptionsChangedListener(new SubscriptionsChangedListener() {
@@ -178,7 +200,4 @@ public class PusherWrapper {
             }
         });
     }
-
-
-
 }

--- a/android/src/main/java/com/b8ne/RNPusherPushNotifications/PusherWrapper.java
+++ b/android/src/main/java/com/b8ne/RNPusherPushNotifications/PusherWrapper.java
@@ -165,8 +165,7 @@ public class PusherWrapper {
         }
     }
 
-    public void setUserId(final String userId, final String token, final Callback errorCallback,
-            final Callback successCallback) {
+    public void setUserId(final String userId, final String token, final Callback errorCallback) {
         Log.d("PUSHER_WRAPPER", "Setting userId to " + userId);
         System.out.print("Setting userId to " + userId);
         try {
@@ -176,7 +175,6 @@ public class PusherWrapper {
 
             Log.d("PUSHER_WRAPPER", "Success! " + userId);
             System.out.print("Success! " + userId);
-            successCallback.invoke();
         } catch (Exception ex) {
             Log.d("PUSHER_WRAPPER", "Exception in PusherWrapper " + ex.getMessage());
             System.out.print("Exception in PusherWrapper.setUserId " + ex.getMessage());

--- a/android/src/main/java/com/b8ne/RNPusherPushNotifications/RNPusherPushNotificationsModule.java
+++ b/android/src/main/java/com/b8ne/RNPusherPushNotifications/RNPusherPushNotificationsModule.java
@@ -93,11 +93,11 @@ public class RNPusherPushNotificationsModule extends ReactContextBaseJavaModule 
     }
 
     @ReactMethod
-    public void setUserId(final String userId, final String token, final Callback errorCallback, final Callback successCallback) {
+    public void setUserId(final String userId, final String token, final Callback errorCallback) {
         AsyncTask.execute(new Runnable() {
             @Override
             public void run() {
-                pusher.setUserId(userId, token, errorCallback, successCallback);
+                pusher.setUserId(userId, token, errorCallback);
             }
         });
     }

--- a/android/src/main/java/com/b8ne/RNPusherPushNotifications/RNPusherPushNotificationsModule.java
+++ b/android/src/main/java/com/b8ne/RNPusherPushNotifications/RNPusherPushNotificationsModule.java
@@ -8,7 +8,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Callback;
 
-
 // SEE: https://docs.pusher.com/beams/reference/android
 
 public class RNPusherPushNotificationsModule extends ReactContextBaseJavaModule {
@@ -89,6 +88,16 @@ public class RNPusherPushNotificationsModule extends ReactContextBaseJavaModule 
             @Override
             public void run() {
                 pusher.getSubscriptions(subscriptionCallback, errorCallback);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void setUserId(final String userId, final String token, final Callback errorCallback, final Callback successCallback) {
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                pusher.setUserId(userId, token, errorCallback, successCallback);
             }
         });
     }

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ export default {
     if (Platform.OS === 'ios') {
       RNPusherPushNotifications.setUserId(userId, token, onError);
     } else {
-      RNPusherPushNotifications.setUserId(userId, token, onError, onSuccess);
+      RNPusherPushNotifications.setUserId(userId, token, onError);
     }
   },
   setOnSubscriptionsChangedListener: (onChange) => {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ export default {
   },
   setUserId: (userId, token, onError, onSuccess) => {
     if (Platform.OS === 'ios') {
-      RNPusherPushNotifications.setUserId(userId, token, onError, onSuccess);
+      RNPusherPushNotifications.setUserId(userId, token, onError);
     } else {
       RNPusherPushNotifications.setUserId(userId, token, onError, onSuccess);
     }

--- a/index.js
+++ b/index.js
@@ -50,6 +50,13 @@ export default {
       RNPusherPushNotifications.unsubscribe(channel, onError, onSuccess);
     }
   },
+  setUserId: (userId, token, onError, onSuccess) => {
+    if (Platform.OS === 'ios') {
+      RNPusherPushNotifications.setUserId(userId, token, onError, onSuccess);
+    } else {
+      RNPusherPushNotifications.setUserId(userId, token, onError, onSuccess);
+    }
+  },
   setOnSubscriptionsChangedListener: (onChange) => {
     if (Platform.OS === 'ios') {
       console.log('Not implemented yet');

--- a/ios/RNPusherLocalTokenProvider.h
+++ b/ios/RNPusherLocalTokenProvider.h
@@ -1,0 +1,21 @@
+//
+//  RNPusherLocalTokenProvider.h
+//  RNPusherPushNotifications
+//
+//  Created by Gianni Settino on 6/25/19.
+//
+
+#import <Foundation/Foundation.h>
+@import PushNotifications;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNPusherLocalTokenProvider : NSObject <TokenProvider>
+
+@property (nonatomic, strong) NSString *_token;
+
+- (instancetype)initWithToken:(NSString *)token;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNPusherLocalTokenProvider.m
+++ b/ios/RNPusherLocalTokenProvider.m
@@ -1,0 +1,26 @@
+//
+//  RNPusherLocalTokenProvider.m
+//  RNPusherPushNotifications
+//
+//  Created by Gianni Settino on 6/25/19.
+//
+
+#import "RNPusherLocalTokenProvider.h"
+
+@implementation RNPusherLocalTokenProvider
+
+- (instancetype)initWithToken:(NSString *)token
+{
+    self = [super init];
+    if (self) {
+        self._token = token;
+    }
+    return self;
+}
+
+- (BOOL)fetchTokenWithUserId:(NSString * _Nonnull)userId error:(NSError *__autoreleasing  _Nullable * _Nullable)error completionHandler:(void (^ _Nonnull)(NSString * _Nonnull, NSError * _Nullable))completion {
+    completion(self._token, nil);
+    return YES;
+}
+
+@end

--- a/ios/RNPusherPushNotifications.m
+++ b/ios/RNPusherPushNotifications.m
@@ -51,7 +51,7 @@ RCT_EXPORT_METHOD(setUserId:(NSString *)userId token:(NSString *)token callback:
     dispatch_async(dispatch_get_main_queue(), ^{
         RNPusherLocalTokenProvider *tokenProvider = [[RNPusherLocalTokenProvider alloc] initWithToken:token];
         [[PushNotifications shared] setUserId:userId tokenProvider:tokenProvider completion:^(NSError *error) {
-            callback(@[error]);
+            //callback(@[error]);
         }];
     });
 }

--- a/ios/RNPusherPushNotifications.m
+++ b/ios/RNPusherPushNotifications.m
@@ -1,4 +1,5 @@
 #import "RNPusherEventHelper.h"
+#import "RNPusherLocalTokenProvider.h"
 #import "RNPusherPushNotifications.h"
 #import "UIKit/UIKit.h"
 #import <UIKit/UIKit.h>
@@ -44,6 +45,15 @@ RCT_EXPORT_METHOD(unsubscribe:(NSString *)interest callback:(RCTResponseSenderBl
     NSError *anyError;
     [[PushNotifications shared] removeDeviceInterestWithInterest:interest error:&anyError];
   });
+}
+
+RCT_EXPORT_METHOD(setUserId:(NSString *)userId token:(NSString *)token callback:(RCTResponseSenderBlock)callback) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        RNPusherLocalTokenProvider *tokenProvider = [[RNPusherLocalTokenProvider alloc] initWithToken:token];
+        [[PushNotifications shared] setUserId:userId tokenProvider:tokenProvider completion:^(NSError *error) {
+            callback(@[error]);
+        }];
+    });
 }
 
 - (void)handleNotification:(NSDictionary *)userInfo

--- a/ios/RNPusherPushNotifications.xcodeproj/project.pbxproj
+++ b/ios/RNPusherPushNotifications.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		68B2C3D622C2CAEC00684CFE /* RNPusherLocalTokenProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 68B2C3D422C2CAEC00684CFE /* RNPusherLocalTokenProvider.m */; };
 		B3E7B58A1CC2AC0600A0062D /* RNPusherPushNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNPusherPushNotifications.m */; };
 		BCA8A1002111819B00AC19BB /* RNPusherEventHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA8A0FF2111819B00AC19BB /* RNPusherEventHelper.m */; };
 /* End PBXBuildFile section */
@@ -25,6 +26,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNPusherPushNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNPusherPushNotifications.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		68B2C3D422C2CAEC00684CFE /* RNPusherLocalTokenProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPusherLocalTokenProvider.m; sourceTree = "<group>"; };
+		68B2C3D522C2CAEC00684CFE /* RNPusherLocalTokenProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPusherLocalTokenProvider.h; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNPusherPushNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPusherPushNotifications.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNPusherPushNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPusherPushNotifications.m; sourceTree = "<group>"; };
 		BCA8A0FE2111817900AC19BB /* RNPusherEventHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPusherEventHelper.h; sourceTree = "<group>"; };
@@ -53,6 +56,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				68B2C3D522C2CAEC00684CFE /* RNPusherLocalTokenProvider.h */,
+				68B2C3D422C2CAEC00684CFE /* RNPusherLocalTokenProvider.m */,
 				BCA8A0FF2111819B00AC19BB /* RNPusherEventHelper.m */,
 				BCA8A0FE2111817900AC19BB /* RNPusherEventHelper.h */,
 				B3E7B5881CC2AC0600A0062D /* RNPusherPushNotifications.h */,
@@ -100,6 +105,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -118,6 +124,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* RNPusherPushNotifications.m in Sources */,
+				68B2C3D622C2CAEC00684CFE /* RNPusherLocalTokenProvider.m in Sources */,
 				BCA8A1002111819B00AC19BB /* RNPusherEventHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
As of February 2019, Pusher Beams supports delivering personal push notifications to authenticated users (announcement here: https://blog.pusher.com/authenticated-users-pusher-beams/).

To do so, you need to identify users using the `setUserId` method on the PushNotification singleton -- we've gone ahead and implemented this call for both Android and iOS.

RCT_EXPORT_METHOD doesn't support passing a TokenProvider object from JS to native code, so we fetch the Beams token (string) in our React code and pass it to the native method. The native method then creates a LocalTokenProvider that implements Pusher's TokenProvider protocol and simply returns the stored token.