### PR TITLE
Android: read extra data from remote notifications

### DIFF
--- a/android/src/main/java/com/b8ne/RNPusherPushNotifications/PusherWrapper.java
+++ b/android/src/main/java/com/b8ne/RNPusherPushNotifications/PusherWrapper.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import android.app.Activity;
 
+import java.util.Map;
 import java.util.Set;
 
 import com.facebook.react.bridge.*;
@@ -69,6 +70,16 @@ public class PusherWrapper {
                     map.putString("icon", notification.getIcon());
                     map.putString("color", notification.getColor());
                     //map.putString("link", notification.getLink());
+
+                    if (remoteMessage.getData() != null) {
+                        WritableMap dataMap = Arguments.createMap();
+                        for (Map.Entry<String, String> e : remoteMessage
+                                .getData()
+                                .entrySet()) {
+                            dataMap.putString(e.getKey(), e.getValue());
+                        }
+                        map.putMap("data", dataMap);
+                    }
 
                     context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(notificationEvent, map);
                     //System.out.print(remoteMessage.toString());


### PR DESCRIPTION
This PR allows reading extra data sent from push notifications on Android (see [data field](https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream)).

I am not able to write or test the corresponding for iOS atm. Anyone is welcome to check that.

I've tested as well with the `0.60.x` PR (#48), and it would be even good to have it in there.