### PR TITLE
Now allowing any and all versions of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "b8ne",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.60.0"
+    "react-native": "*"
   },
   "bugs": {
     "url": "https://github.com/b8ne/react-native-pusher-push-notifications/issues"


### PR DESCRIPTION
Updated `peerDependencies` to allow any version of react native. (Fixes #67)

I feel like limiting this potentially causes more harm than it helps, but let me know if you want me to fix it to a minimum version 👍