### PR TITLE
Return listeners on `.on()` calls for later cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ export const init = () => {
 
   // Setup notification listeners
   RNPusherPushNotifications.on('notification', handleNotification);
+
+  // Optionally you can assign the listeners to variables so you can clean them up later.
+  //    const listener = RNPusherPushNotifications.on('registered', () => {});
+  //    listener.remove();
 };
 
 // Handle notifications received

--- a/index.js
+++ b/index.js
@@ -69,9 +69,9 @@ export default {
   },
   on: (eventName, callback) => {
     if (Platform.OS === 'ios') {
-      rnPusherPushNotificationsEmitter.addListener(eventName, payload => callback(payload));
+      return rnPusherPushNotificationsEmitter.addListener(eventName, payload => callback(payload));
     } else {
-      DeviceEventEmitter.addListener(eventName, payload => callback(payload));
+      return DeviceEventEmitter.addListener(eventName, payload => callback(payload));
     }
   },
 };


### PR DESCRIPTION
Hi,

This small change returns the listener created by the `RNPusherPushNotifications.on()` call, so that we can clean it up if we want to. This is helpful in logout - re-login flow where the listeners from a previous login keeps lingering and listening to new events.

```
// On login
const registerListener = RNPusherPushNotifications.on('registered', () => {});
const notificationListener = RNPusherPushNotifications.on('notification', () => {});

// On logout
registerListener.remove();
notificationListener.remove();
```

Hoping for this to be merged to upstream. Thanks!