### PR TITLE
Remove jcenter from the list of repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -12,7 +12,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com'
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.google.firebase:firebase-core:16.0.1'
     implementation 'com.google.firebase:firebase-messaging:17.3.4'
-    implementation 'com.pusher:push-notifications-android:1.4.5'
+    implementation 'com.pusher:push-notifications-android:1.9.0'
 
 }


### PR DESCRIPTION
Replace it with mavenCentral.

JCenter announced on February 3 2021 that it would shutdown.
They later decided to keep the repository as read-only indefinitely, but that also means no new versions of packages will be uploaded to it.

Lately the jcenter repository has been giving a lot of 502 Bad Gateway errors, making downstream builds flaky. I think it's finally time to remove it.

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

## Issues
~It seems there's a dependency on a library that only exists on jcenter: com.firebase:firebase-jobdispatcher:0.8.5.~ Updating the push-notifications-android dependency to the latest version (1.9.0) fixes this issue.