### PR TITLE
Update build.gradle compileSdkVersion & targetSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,12 +27,12 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
The specified Android SDK Build Tools version (28.0.3) is ignored, as it is below the minimum supported version (30.0.3) for Android Gradle Plugin 7.4.2.

Android SDK Build Tools 30.0.3 will be used.

